### PR TITLE
Remove unnecessary beforeEach block

### DIFF
--- a/packages/jest-enzyme/src/index.js
+++ b/packages/jest-enzyme/src/index.js
@@ -11,43 +11,40 @@ import enzymeMatchers from 'enzyme-matchers';
 import serializer from 'enzyme-to-json/serializer';
 
 declare var expect: Function;
-declare var beforeEach: Function;
 
 // add the snapshot serializer for Enzyme wrappers
 expect.addSnapshotSerializer(serializer);
 
 // add methods!
-beforeEach(() => {
-  const matchers = {};
+const matchers = {};
 
-  Object.keys(enzymeMatchers).forEach(matcherKey => {
-    const matcher = {
-      [matcherKey](wrapper, ...args) {
-        const result = enzymeMatchers[matcherKey].call(this, wrapper, ...args);
+Object.keys(enzymeMatchers).forEach(matcherKey => {
+  const matcher = {
+    [matcherKey](wrapper, ...args) {
+      const result = enzymeMatchers[matcherKey].call(this, wrapper, ...args);
 
-        let message = this.isNot ? result.negatedMessage : result.message;
+      let message = this.isNot ? result.negatedMessage : result.message;
 
-        if (result.contextualInformation.expected) {
-          message += `\n${this.utils.RECEIVED_COLOR(
-            result.contextualInformation.expected
-          )}`;
-        }
+      if (result.contextualInformation.expected) {
+        message += `\n${this.utils.RECEIVED_COLOR(
+          result.contextualInformation.expected
+        )}`;
+      }
 
-        if (result.contextualInformation.actual) {
-          message += `\n${this.utils.EXPECTED_COLOR(
-            result.contextualInformation.actual
-          )}`;
-        }
+      if (result.contextualInformation.actual) {
+        message += `\n${this.utils.EXPECTED_COLOR(
+          result.contextualInformation.actual
+        )}`;
+      }
 
-        return {
-          ...result,
-          message: () => message,
-        };
-      },
-    }[matcherKey];
+      return {
+        ...result,
+        message: () => message,
+      };
+    },
+  }[matcherKey];
 
-    matchers[matcherKey] = matcher;
-  });
-
-  expect.extend(matchers);
+  matchers[matcherKey] = matcher;
 });
+
+expect.extend(matchers);


### PR DESCRIPTION
`expect.extend` is available at the top level, so no need to wrap in the
`beforeEach`. Looks like some legacy holdover from when `jest-enzyme`
and `jasmine-enzyme` were the same library.